### PR TITLE
Update httpx dependency to version 0.28.1 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 INSTALL_REQUIRES = [
     "webtest",
     "starlette>=0.21.0",
-    "httpx~=0.23.0",  # starlette >= v0.21.0 requires httpx for TestClient
+    "httpx~=0.28.1",  # starlette >= v0.21.0 requires httpx for TestClient
     # Needed by starlette for form parsing
     "python-multipart",
 ]


### PR DESCRIPTION
## Update httpx to Mitigate CVE-2025-43859

### Summary

This pull request updates the httpx dependency to a version that mitigates [CVE-2025-43859](https://nvd.nist.gov/vuln/detail/CVE-2025-43859), a critical vulnerability in the h11 library (used by httpx) that could allow HTTP request smuggling under certain conditions.

### Details

- **CVE-2025-43859**: h11 (a dependency of httpx) had a leniency in parsing line terminators in chunked-coding message bodies, potentially leading to request smuggling vulnerabilities. This issue is fixed in h11 version 0.16.0 and later.
- The updated httpx version ensures that a secure version of h11 is used, closing this vulnerability.
- Reference: [NVD CVE-2025-43859](https://nvd.nist.gov/vuln/detail/CVE-2025-43859)

### Changes

- Bumped httpx version in `setup.py` to ensure compatibility with h11 >= 0.16.0.

### Impact

- This change addresses a critical security issue and is recommended for all users.
- No breaking changes are expected, but please report any issues encountered after the upgrade.